### PR TITLE
Fix README typos and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ css/
   _buttons.css
   _forms.css
   _components.css
-  __kitechen-sink.css
+  __kitchen-sink.css
   overrides.css
   main.css
 
@@ -52,7 +52,7 @@ fonts/
 
 js/
   main.js
-  sing-up.js
+  sign-up.js
 
 templates/
   system/

--- a/css/_components.css
+++ b/css/_components.css
@@ -341,6 +341,7 @@ header.sticky {
 
 .card--content h3 {
   margin-bottom: 0.75rem;
+  font-family: var(--body-font-family);
 }
 
 .card--content p {

--- a/css/_variables.css
+++ b/css/_variables.css
@@ -20,6 +20,7 @@
   --form-label-color: #6a6a6a;
   --form-checkbox-color: #dedede;
   --soft-shadow: drop-shadow(0 2px 10px 0 rgba(0, 0, 0, 0.14));
+  --medium-shadow: drop-shadow(0 4px 15px rgba(0, 0, 0, 0.12));
   --hard-shadow: drop-shadow(0px 163.333px 130.667px rgba(0, 0, 0, 0.07))
     drop-shadow(0px 68.2368px 54.5894px rgba(0, 0, 0, 0.0503198))
     drop-shadow(0px 36.4826px 29.1861px rgba(0, 0, 0, 0.0417275))

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Classpass | Sign Up</title>
+    <title>ClassPass | Sign Up</title>
     <link rel="stylesheet" href="./css/main.css">
   </head>
 

--- a/templates/landing-page.html
+++ b/templates/landing-page.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Classpass | Pickleball Tournament</title>
+    <title>ClassPass | Pickleball Tournament</title>
     <link rel="stylesheet" href="../css/main.css">
   </head>
 

--- a/templates/system/sign-up.html
+++ b/templates/system/sign-up.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Classpass | Sign Up</title>
+    <title>ClassPass | Sign Up</title>
     <link rel="stylesheet" href="../../css/main.css">
   </head>
 
@@ -109,6 +109,7 @@
               <div class="input--group">
                 <select class="experience" required>
                   <option value="" disabled selected>Please select</option>
+                  <option value="beginner">Beginner</option>
                   <option value="novice">Novice</option>
                   <option value="intermediate">Intermediate</option>
                   <option value="advanced">Advanced</option>

--- a/templates/system/thank-you.html
+++ b/templates/system/thank-you.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Classpass | Thank you!</title>
+    <title>ClassPass | Thank you!</title>
     <link rel="stylesheet" href="../../css/main.css">
   </head>
 


### PR DESCRIPTION
## Summary
- correct file names in README
- add missing medium shadow variable
- update page titles to `ClassPass`
- add beginner option to sign-up page
- ensure What to Expect card headings use the body font

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f4355b1f8832991e04d31edd5e6d4